### PR TITLE
Added rotating towards specific rotation by holding SHIFT and pressing left or right arrow

### DIFF
--- a/YAGA/Compass.cpp
+++ b/YAGA/Compass.cpp
@@ -2,10 +2,22 @@
 // Union SOURCE file
 
 namespace GOTHIC_ENGINE {
-	int GetCompassAngle() {
+	const int compassAngleOffset = 45;
+
+	float GetCompassAngle() {
 		zVEC3 atVectorWorld3D = player->GetAtVectorWorld();
 		zVEC2 atVectorWorld2D = zVEC2( atVectorWorld3D[VX], atVectorWorld3D[VZ] );
-		int atVectorAngle = (int)( atVectorWorld2D.GetAngle() * DEGREE );
-		return atVectorAngle;
+		return atVectorWorld2D.GetAngle() * DEGREE;
+	}
+
+	void RotateTowardsCompassAngle(int direction) {
+		float currentAngle = GetCompassAngle();
+
+		int remainder = static_cast<int>(currentAngle) % compassAngleOffset;
+		if (direction == 1)
+			remainder = compassAngleOffset - remainder;
+
+		float offsetAngle = remainder != 0 ? remainder * direction : compassAngleOffset * direction;
+		player->RotateLocalY(offsetAngle);
 	}
 }

--- a/YAGA/Compass.h
+++ b/YAGA/Compass.h
@@ -2,5 +2,6 @@
 // Union HEADER file
 
 namespace GOTHIC_ENGINE {
-	int GetCompassAngle();
+	float GetCompassAngle();
+	void RotateTowardsCompassAngle(int direction);
 }

--- a/YAGA/CompassReader.cpp
+++ b/YAGA/CompassReader.cpp
@@ -7,5 +7,27 @@ namespace GOTHIC_ENGINE {
 			int compassAngle = GetCompassAngle();
 			Read(GetCompassName(compassAngle).AToW());
 		}
+
+		if (zKeyPressed( KEY_LSHIFT ) || zKeyPressed(KEY_RSHIFT)) {
+			if (zKeyToggled(KEY_LEFTARROW)) {
+				RotateTowardsCompassAngle(-1);
+
+				int compassAngle = GetCompassAngle();
+				Read(GetCompassName(compassAngle).AToW());
+			}
+
+			if (zKeyToggled(KEY_RIGHTARROW)) {
+				RotateTowardsCompassAngle(1);
+
+				int compassAngle = GetCompassAngle();
+				Read(GetCompassName(compassAngle).AToW());
+			}
+		}
+	}
+
+	HOOK Hook_oCAIHuman_PC_Turnings AS(&oCAIHuman::PC_Turnings, &oCAIHuman::PC_Turnings_Union);
+	void oCAIHuman::PC_Turnings_Union(zBOOL forceRotation) {
+		if (!zKeyPressed(KEY_LSHIFT) && !zKeyPressed(KEY_RSHIFT))
+			THISCALL(Hook_oCAIHuman_PC_Turnings)(forceRotation);
 	}
 }

--- a/YAGA/ZenGin/Gothic_UserAPI/oCAIHuman.inl
+++ b/YAGA/ZenGin/Gothic_UserAPI/oCAIHuman.inl
@@ -4,3 +4,4 @@
 // Add your methods here
 
 void StartFlyDamage_Union( float, zVEC3& );
+void PC_Turnings_Union(zBOOL forceRotation);


### PR DESCRIPTION
- Added `RotateTowardsCompassAngle` function, function expects either `-1` or `1` as argument
- Added `compassAngleOffset` variable, for now it is set to const, but this should be changed in the future (maybe someone would like to customize the compas offset angle)
- Added `Hook_oCAIHuman_PC_Turnings` for disabling turning player while holding shift key