### PR TITLE
Migrate to Csound as audio generator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,3 @@
 # LFS files
 *.exe filter=lfs diff=lfs merge=lfs -text
 *.dll filter=lfs diff=lfs merge=lfs -text
-*.wav filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 # Local binaries
 /vdf/System/Autorun/YAGA.dll
 /vdf/yaga.vdf
+/vdf/_Work/Data/Sound/SFX/*.WAV
+/vdf/_Work/Data/Sound/SFX/*.wav
 
 # macOS
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,9 +44,45 @@ add_subdirectory(dependencies)
 
 set(VDF_DIR "${PROJECT_SOURCE_DIR}/vdf/")
 set(VDF_AUTORUN_DIR "${VDF_DIR}System/Autorun/")
+set(VDF_SOUND_DIR "${VDF_DIR}_Work/Data/Sound/SFX/")
 
 set(VDF_BUILD_VM_FILE "${VDF_DIR}build.vm")
 string(REPLACE "/" "\\" VDF_BUILD_VM_FILE "${VDF_BUILD_VM_FILE}")
+
+option(YAGA_BUILD_SOUNDS "Build sound assets from Csound sources" ON)
+
+if (YAGA_BUILD_SOUNDS)
+	find_program(CSOUND NAMES csound csound64)
+	if (NOT CSOUND)
+		message(FATAL_ERROR "Csound not found. Install Csound or configure with -DYAGA_BUILD_SOUNDS=OFF.")
+	endif()
+
+	file(GLOB CSOUND_SOURCE_FILES CONFIGURE_DEPENDS
+		"${PROJECT_SOURCE_DIR}/audio/csound/cues/*.csd"
+	)
+
+	set(SOUND_OUTPUT_FILES)
+	foreach(CSOUND_SOURCE_FILE ${CSOUND_SOURCE_FILES})
+		get_filename_component(SOUND_NAME "${CSOUND_SOURCE_FILE}" NAME_WE)
+		set(SOUND_OUTPUT_FILE "${VDF_SOUND_DIR}${SOUND_NAME}.WAV")
+
+		add_custom_command(
+			OUTPUT "${SOUND_OUTPUT_FILE}"
+			COMMAND ${CMAKE_COMMAND} -E make_directory "${VDF_SOUND_DIR}"
+			COMMAND ${CSOUND} -+ignore_csopts=1 -d -W -o "${SOUND_OUTPUT_FILE}" "${CSOUND_SOURCE_FILE}"
+			DEPENDS "${CSOUND_SOURCE_FILE}"
+			COMMENT "[Sound] Rendering ${SOUND_NAME}.WAV"
+			VERBATIM
+		)
+
+		list(APPEND SOUND_OUTPUT_FILES "${SOUND_OUTPUT_FILE}")
+	endforeach()
+
+	add_custom_target(sounds
+		DEPENDS ${SOUND_OUTPUT_FILES}
+	)
+	add_dependencies(${CMAKE_PROJECT_NAME} sounds)
+endif()
 
 add_custom_command(TARGET ${CMAKE_PROJECT_NAME}
 		POST_BUILD

--- a/audio/csound/cues/CHASM.csd
+++ b/audio/csound/cues/CHASM.csd
@@ -1,0 +1,43 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -W -o CHASM.wav
+</CsOptions>
+
+<CsInstruments>
+sr     = 44100
+ksmps  = 32
+nchnls = 1
+0dbfs  = 1
+
+giSine ftgen 1, 0, 4096, 10, 1
+
+instr 1
+    iAmp  = p4
+    iFreq = p5
+    iAtk  = 0.0015
+    iMid  = p3 * 0.42
+    iTail = p3 - iAtk - iMid
+
+    ; Very short alert beep shaped to fit the note duration.
+    aEnv   linseg 0, iAtk, 1, iMid, 0.55, iTail, 0
+    aTone  oscili iAmp, iFreq, 1
+    aUpper oscili iAmp * 0.22, iFreq * 2, 1
+    aSub   oscili iAmp * 0.12, iFreq * 0.5, 1
+
+    aOut = (aTone + aUpper + aSub) * aEnv
+    out aOut
+endin
+</CsInstruments>
+
+<CsScore>
+; Tempo-based score: rapid trill between F#5 and G5 at 120 BPM.
+t 0 120
+i 1 0.00 0.0625 0.48 739.99
+i 1 0.0625 0.0625 0.48 783.99
+i 1 0.1250 0.0625 0.48 739.99
+i 1 0.1875 0.0625 0.48 783.99
+i 1 0.2500 0.0625 0.48 739.99
+i 1 0.3125 0.0625 0.48 783.99
+e 0.50
+</CsScore>
+</CsoundSynthesizer>

--- a/audio/csound/cues/WALLHUMFAR.csd
+++ b/audio/csound/cues/WALLHUMFAR.csd
@@ -1,0 +1,41 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -W -o WALLHUMFAR.wav
+</CsOptions>
+
+<CsInstruments>
+sr     = 44100
+ksmps  = 32
+nchnls = 1
+0dbfs  = 1
+
+instr 1
+    iAmp = p4
+    iCf  = p5
+    iBw  = p6
+
+    ; Softer, lower click than WALLHUMNEAR so the two cues stay distinguishable.
+    aSnapExc rand iAmp
+    aBodyExc rand iAmp * 0.70
+
+    aSnapEnv linseg 0, 0.0003, 1, 0.006, 0
+    aBodyEnv linseg 0, 0.0010, 1, 0.024, 0.34, 0.026, 0
+
+    aSnap = aSnapExc * aSnapEnv
+    aBody = aBodyExc * aBodyEnv
+
+    aClick reson aSnap, iCf, iBw
+    aAir   reson aSnap, iCf * 1.55, iBw * 0.75
+    aKnock reson aBody, iCf * 0.48, iBw * 2.10
+
+    aOut = ((aClick * 0.52) + (aAir * 0.14) + (aKnock * 0.90)) * 0.18
+    out aOut
+endin
+</CsInstruments>
+
+<CsScore>
+; Single lower wall click with a softer, boxier tail.
+i 1 0.00 0.06 0.74 2550 1150
+e 0.14
+</CsScore>
+</CsoundSynthesizer>

--- a/audio/csound/cues/WALLHUMNEAR.csd
+++ b/audio/csound/cues/WALLHUMNEAR.csd
@@ -1,0 +1,44 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -W -o WALLHUMNEAR.wav
+</CsOptions>
+
+<CsInstruments>
+sr     = 44100
+ksmps  = 32
+nchnls = 1
+0dbfs  = 1
+
+instr 1
+    iAmp = p4
+    iCf  = p5
+    iBw  = p6
+
+    ; Split the transient into a bright snap and a slightly slower body layer.
+    aSnapExc rand iAmp
+    aBodyExc rand iAmp * 0.60
+
+    aSnapEnv linseg 0, 0.0002, 1, 0.005, 0
+    aBodyEnv linseg 0, 0.0008, 1, 0.018, 0.30, 0.020, 0
+
+    aSnap = aSnapExc * aSnapEnv
+    aBody = aBodyExc * aBodyEnv
+
+    ; The bright layer gives directional definition.
+    aClick reson aSnap, iCf, iBw
+    aAir   reson aSnap, iCf * 1.9, iBw * 0.65
+
+    ; The lower band adds weight so the click feels fuller.
+    aKnock reson aBody, iCf * 0.55, iBw * 1.8
+
+    aOut = ((aClick * 0.75) + (aAir * 0.22) + (aKnock * 0.70)) * 0.19
+    out aOut
+endin
+</CsInstruments>
+
+<CsScore>
+; Single fuller click with a short tail.
+i 1 0.00 0.05 0.78 3400 950
+e 0.12
+</CsScore>
+</CsoundSynthesizer>

--- a/audio/csound/cues/WHISPERINGCHEST.csd
+++ b/audio/csound/cues/WHISPERINGCHEST.csd
@@ -1,0 +1,46 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -W -o WHISPERINGCHEST.wav
+</CsOptions>
+
+<CsInstruments>
+sr     = 44100
+ksmps  = 32
+nchnls = 1
+0dbfs  = 1
+
+giSine ftgen 1, 0, 4096, 10, 1
+
+instr 1
+    iAmp  = p4
+    iFreq = p5
+    iAtk  = 0.001
+    iBody = p3 * 0.20
+    iTail = p3 - iAtk - iBody
+
+    ; Small natural bell: stable partials and a clean ringing decay.
+    aEnvA     linseg 0, iAtk, 1, 0.030, 0.34, p3 - 0.031, 0
+    aEnvB     linseg 0, iAtk, 1, 0.024, 0.26, p3 - 0.025, 0
+    aEnvC     linseg 0, iAtk, 1, 0.018, 0.20, p3 - 0.019, 0
+    aStrike   linseg 0, 0.0008, 1, 0.008, 0
+
+    aBellA    oscili iAmp * 0.15, iFreq, 1
+    aBellB    oscili iAmp * 0.11, iFreq * 2.00, 1
+    aBellC    oscili iAmp * 0.08, iFreq * 2.52, 1
+    aBellD    oscili iAmp * 0.04, iFreq * 3.00, 1
+
+    aStrikeN  rand iAmp * 0.03
+    aStrikeHi reson aStrikeN * aStrike, iFreq * 7.0, iFreq * 2.0
+
+    aOut = (aBellA * aEnvA) + (aBellB * aEnvA * 0.92) + (aBellC * aEnvB) + (aBellD * aEnvC)
+    aOut = aOut + (aStrikeHi * 0.08)
+    out aOut * 1.75
+endin
+</CsInstruments>
+
+<CsScore>
+; One short natural bell icon.
+i 1 0.00 0.20 0.52 659.25
+e 0.26
+</CsScore>
+</CsoundSynthesizer>

--- a/audio/csound/cues/WHISPERINGITEM.csd
+++ b/audio/csound/cues/WHISPERINGITEM.csd
@@ -1,0 +1,47 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -W -o WHISPERINGITEM.wav
+</CsOptions>
+
+<CsInstruments>
+sr     = 44100
+ksmps  = 32
+nchnls = 1
+0dbfs  = 1
+
+giSine ftgen 1, 0, 4096, 10, 1
+
+instr 1
+    iAmp  = p4
+    iFreq = p5
+    iAtk  = 0.001
+    iBody = p3 * 0.30
+    iTail = p3 - iAtk - iBody
+
+    ; Thicker hollow-box knock: more low-mid body, less click-like edge.
+    aEnv      linseg 0, iAtk, 1, iBody, 0.52, iTail, 0
+    kPitch    linseg iFreq * 1.10, 0.014, iFreq, p3 - 0.014, iFreq * 0.92
+    aCore     oscili iAmp, kPitch, 1
+    aCoreDet  oscili iAmp * 0.18, kPitch * 0.992, 1
+    aBoxLow   oscili iAmp * 0.42, kPitch * 0.68, 1
+    aBoxMid   oscili iAmp * 0.28, kPitch * 1.34, 1
+    aBoxHigh  oscili iAmp * 0.03, kPitch * 2.05, 1
+
+    aKnockExc rand iAmp * 0.12
+    aKnockEnv linseg 0, 0.0009, 1, 0.012, 0
+    aCavityLo reson aKnockExc * aKnockEnv, 520, 320
+    aCavityMd reson aKnockExc * aKnockEnv, 930, 440
+    aCavityHi reson aKnockExc * aKnockEnv, 1620, 700
+
+    aOut = ((aCore * 0.66) + (aCoreDet * 0.28) + (aBoxLow * 0.92) + (aBoxMid * 0.66) + (aBoxHigh * 0.04) +
+           (aCavityLo * 0.92) + (aCavityMd * 0.56) + (aCavityHi * 0.06)) * aEnv * 0.42
+    out aOut
+endin
+</CsInstruments>
+
+<CsScore>
+; One short thick hollow-box item knock centered around a lower G.
+i 1 0.00 0.16 0.55 196.00
+e 0.24
+</CsScore>
+</CsoundSynthesizer>

--- a/audio/csound/cues/WHISPERINGNPC.csd
+++ b/audio/csound/cues/WHISPERINGNPC.csd
@@ -1,0 +1,46 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -W -o WHISPERINGNPC.wav
+</CsOptions>
+
+<CsInstruments>
+sr     = 44100
+ksmps  = 32
+nchnls = 1
+0dbfs  = 1
+
+giSine ftgen 1, 0, 4096, 10, 1
+
+instr 1
+    iAmp  = p4
+    iFreq = p5
+    iAtk  = 0.002
+    iBody = p3 * 0.18
+    iSoft = p3 * 0.28
+    iTail = p3 - iAtk - iBody - iSoft
+
+    ; Soft, short musical ping that should transpose cleanly for health cues.
+    aEnv    linseg 0, iAtk, 1, iBody, 0.46, iSoft, 0.20, iTail, 0
+    kPitch  linseg iFreq * 1.02, 0.010, iFreq, p3 - 0.010, iFreq * 0.998
+    aFund   oscili iAmp, kPitch, 1
+    aDetune oscili iAmp * 0.20, kPitch * 0.997, 1
+    aOct    oscili iAmp * 0.20, kPitch * 2, 1
+    aFifth  oscili iAmp * 0.10, kPitch * 3, 1
+    aWarm   oscili iAmp * 0.18, kPitch * 0.5, 1
+
+    ; A short filtered transient makes the note speak quickly without becoming sharp.
+    aAirExc rand iAmp * 0.12
+    aAirEnv linseg 0, 0.001, 1, 0.013, 0
+    aAir    reson aAirExc * aAirEnv, iFreq * 2.2, iFreq * 0.95
+
+    aOut = ((aFund * 0.78) + (aDetune * 0.35) + aOct + aFifth + (aWarm * 0.75) + (aAir * 0.30)) * aEnv * 0.70
+    out aOut
+endin
+</CsInstruments>
+
+<CsScore>
+; One short soft ping on A4. Distance-based repetition and health mapping will be handled in code later.
+i 1 0.00 0.16 0.42 440.00
+e 0.22
+</CsScore>
+</CsoundSynthesizer>

--- a/vdf/_Work/Data/Sound/SFX/CHASM.WAV
+++ b/vdf/_Work/Data/Sound/SFX/CHASM.WAV
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:355a98330cc838871dcfac1908fca3e0f3cf7076395183228cf8b01abc5a1149
-size 35572

--- a/vdf/_Work/Data/Sound/SFX/SMALLBELLRINGING.WAV
+++ b/vdf/_Work/Data/Sound/SFX/SMALLBELLRINGING.WAV
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf2d9e79f296405f83f975b125af30bd2c9a692a0994f650ef17181a03e84ee6
-size 39371

--- a/vdf/_Work/Data/Sound/SFX/WALLBEEP.WAV
+++ b/vdf/_Work/Data/Sound/SFX/WALLBEEP.WAV
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:001f66d73dfed4af1c6015f8fd81ff8dc83697e2de0ecceb97b282cbc00288d1
-size 45250

--- a/vdf/_Work/Data/Sound/SFX/WALLHUMFAR.WAV
+++ b/vdf/_Work/Data/Sound/SFX/WALLHUMFAR.WAV
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:001f66d73dfed4af1c6015f8fd81ff8dc83697e2de0ecceb97b282cbc00288d1
-size 45250

--- a/vdf/_Work/Data/Sound/SFX/WALLHUMNEAR.WAV
+++ b/vdf/_Work/Data/Sound/SFX/WALLHUMNEAR.WAV
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4064dc03974303b47afe0dc49f944104bf62a4606473058fff3567e72f81f78
-size 41029

--- a/vdf/_Work/Data/Sound/SFX/WHISPERINGCHEST.WAV
+++ b/vdf/_Work/Data/Sound/SFX/WHISPERINGCHEST.WAV
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08c6ba40168846fd753118e80d0618ad03aa1f48f94d3085ed323a1d44db3727
-size 100180

--- a/vdf/_Work/Data/Sound/SFX/WHISPERINGITEM.WAV
+++ b/vdf/_Work/Data/Sound/SFX/WHISPERINGITEM.WAV
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41de1cbaaf2ed8a92562a9aa9c8548e40add339daee8ac9e1246bf5e7c7f84fa
-size 55238

--- a/vdf/_Work/Data/Sound/SFX/WHISPERINGNPC.WAV
+++ b/vdf/_Work/Data/Sound/SFX/WHISPERINGNPC.WAV
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9623e3d7a1acd71562bed71ad4ff6d6730372cecd4a757920b0a2d57ab7add2f
-size 34694


### PR DESCRIPTION
The current assets of Yaga had multiple issues. I will name just a few
1. We used macOS 9 sounds (license violation).
2. The sounds were inconsistent and all over the place.

I have migrated Yaga to use the [Csound](https://csound.com) command line tool and audio programming language. This gives us the full control over the sounds, as well as it makes it possible to add new ones pretty easily.